### PR TITLE
adds format string for created-at

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,7 @@ func printTodo(i int, t todo) string {
 		since := t.CompletedAt.Sub(t.CreatedAt)
 		elapsedTime = since - (since % time.Minute)
 	}
-	return fmt.Sprintf("%d | %s | %v | %v | %v", i, t.Description, t.Completed, t.CreatedAt, elapsedTime)
+	return fmt.Sprintf("%d | %s | %v | %v | %v", i, t.Description, t.Completed, t.CreatedAt.Format("2006-01-02@03:04:05"), elapsedTime)
 }
 
 func write(todos []todo, app todoApp) error {


### PR DESCRIPTION
I find this pretty unintuitive, I'm wondering why this method is chosen
vs an implementation of stftime. But I digress.